### PR TITLE
Update cvmfs-lsst/README.md

### DIFF
--- a/cvmfs-lsst/README.md
+++ b/cvmfs-lsst/README.md
@@ -24,6 +24,8 @@ Creating user data directory: /root/.eups
 
 [root@dev lsst]# yum install -y git
 
+[root@dev lsst]# cd /tmp
+
 [root@dev lsst]# git clone http://git.lsstcorp.org/contrib/demos/lsst_dm_stack_demo.git
 Cloning into 'lsst_dm_stack_demo'...
 remote: Counting objects: 495, done.


### PR DESCRIPTION
The /cvmfs/lsst.in2p3.fr/software/x86_64-slc6/lsst-v9.2/ directory is read-only, so cd /tmp.