### PR TITLE
Remove VOLUME directive in cvmfs-base

### DIFF
--- a/cvmfs-base/Dockerfile
+++ b/cvmfs-base/Dockerfile
@@ -54,8 +54,6 @@ RUN chmod uga+rx \
 	/usr/bin/cubied \
 	;
 
-VOLUME ["/cvmfs"]
-
 ## make the whole container seamlessly executable
 ENTRYPOINT ["/usr/bin/cubied"]
 CMD ["bash"]


### PR DESCRIPTION
Exposing /cvmfs as a VOLUME in the base image seems to prevent
Dockerfiles of deriviative images from making persistent changes to this
directory. In particular, in cvmfs-atlas one gets an error at runtime
because the /cvmfs/atlas.cern.ch directory is missing, despite the fact
that it is created by the Dockerfile at build-time.

Note that end-users can easily expose /cvmfs as a volume at invocation-time with the -v flag, or by using docker-compose.