### PR TITLE
Replacing cubied with run-cvmfs.sh (issue #20)

### DIFF
--- a/cvmfs-base/Dockerfile
+++ b/cvmfs-base/Dockerfile
@@ -8,7 +8,6 @@ MAINTAINER Sebastien Binet "binet@cern.ch"
 USER root
 ENV USER root
 ENV HOME /root
-ENV CUBIED_VERSION 20160205
 
 ## make sure FUSE can be enabled
 RUN if [[ ! -e /dev/fuse ]]; then mknod -m 666 /dev/fuse c 10 229; fi
@@ -31,7 +30,7 @@ RUN yum update -y && yum install -y \
 RUN mkdir -p \
     /cvmfs/cernvm-prod.cern.ch \
     /cvmfs/sft.cern.ch \
-	/etc/cubie.d
+	  ;
 
 RUN echo "cernvm-prod.cern.ch /cvmfs/cernvm-prod.cern.ch cvmfs defaults 0 0" >> /etc/fstab && \
     echo "sft.cern.ch         /cvmfs/sft.cern.ch cvmfs defaults 0 0" >> /etc/fstab
@@ -39,24 +38,20 @@ RUN echo "cernvm-prod.cern.ch /cvmfs/cernvm-prod.cern.ch cvmfs defaults 0 0" >> 
 WORKDIR /root
 
 ## add files last (as this invalids caches)
-ADD https://github.com/hepsw/cubie/releases/download/${CUBIED_VERSION}/cubied /usr/bin/cubied
 ADD dot-pythonrc.py  $HOME/.pythonrc.py
 
 ADD etc-cvmfs-default-local /etc/cvmfs/default.local
 ADD etc-cvmfs-domain-local  /etc/cvmfs/domain.d/cern.ch.local
 ADD etc-cvmfs-keys          /etc/cvmfs/keys
 
-ADD etc-cubied-cvmfs.conf /etc/cubie.d/cvmfs.conf
 ADD run-cvmfs.sh /etc/cvmfs/run-cvmfs.sh
 
 RUN chmod uga+rx \
 	/etc/cvmfs/run-cvmfs.sh \
-	/usr/bin/cubied \
 	;
 
 ## make the whole container seamlessly executable
-ENTRYPOINT ["/usr/bin/cubied"]
+ENTRYPOINT ["/etc/cvmfs/run-cvmfs.sh"]
 CMD ["bash"]
 
 ## EOF
-

--- a/cvmfs-base/etc-cubied-cvmfs.conf
+++ b/cvmfs-base/etc-cubied-cvmfs.conf
@@ -1,3 +1,0 @@
-{
-	"Cmd": "/etc/cvmfs/run-cvmfs.sh"
-}

--- a/cvmfs-base/run-cvmfs.sh
+++ b/cvmfs-base/run-cvmfs.sh
@@ -6,3 +6,5 @@ cvmfs_config setup || exit 1
 echo "::: mounting FUSE..."
 mount -a
 echo "::: mounting FUSE... [done]"
+
+exec "$@"


### PR DESCRIPTION
PR regarding issue #20 
 - removed all traces of cubied
 - modified `run-cvmfs.sh` to execute the CMD
 - changed ENTRYPOINT `cubied` &rarr; `run-cvmfs.sh`

Tested with
```bash
docker build -t hepsw/cvmfs-base .
docker run --privileged -ti hepsw/cvmfs-base ls -l /cvmfs/sft.cern.ch/lcg/
```