### PR TITLE
Adding CC7 versions (base, CMS, LZ)

### DIFF
--- a/cc7-base/Dockerfile
+++ b/cc7-base/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Sebastien Binet "binet@cern.ch"
 
 # add CERN CentOS yum repo
 ADD http://linux.web.cern.ch/linux/centos7/CentOS-CERN.repo /etc/yum.repos.d/CentOS-CERN.repo
-ADD http://linuxsoft.cern.ch/cern/centos/7.1/os/x86_64/RPM-GPG-KEY-cern /tmp/RPM-GPG-KEY-cern
+ADD http://linuxsoft.cern.ch/cern/centos/7/os/x86_64/RPM-GPG-KEY-cern /tmp/RPM-GPG-KEY-cern
 
 RUN /usr/bin/rpm --import /tmp/RPM-GPG-KEY-cern && \
     /bin/rm /tmp/RPM-GPG-KEY-cern

--- a/cc7-base/Makefile
+++ b/cc7-base/Makefile
@@ -1,15 +1,14 @@
 .PHONY: all build
 
 REPO := hepsw/cc7-base
-TAG := 7.1
+TAG := 7
 
 all: build
 	@echo "done"
 
 build: Dockerfile
 	docker build --rm --tag=$(REPO):$(TAG) .
-	docker tag --force $(REPO):$(TAG) $(REPO):latest
+	docker tag $(REPO):$(TAG) $(REPO):latest
 
 upload: build
 	docker push $(REPO):$(TAG)
-

--- a/cvmfs-base/Dockerfile-cc7
+++ b/cvmfs-base/Dockerfile-cc7
@@ -1,0 +1,61 @@
+##
+## hepsw/cvmfs-base
+## A container where CernVM-FS is up and running
+##
+FROM hepsw/cc7-base
+LABEL maintainer="Sebastien Binet <binet@cern.ch>"
+
+USER root
+ENV USER root
+ENV HOME /root
+ENV CUBIED_VERSION 20160205
+
+## make sure FUSE can be enabled
+RUN if [[ ! -e /dev/fuse ]]; then mknod -m 666 /dev/fuse c 10 229; fi
+
+# install cvmfs repos
+ADD etc-yum-cernvm.repo /etc/yum.repos.d/cernvm.repo
+
+# Install rpms
+RUN yum update -y && yum install -y \
+    cvmfs cvmfs-auto-setup cvmfs-config-default \
+	csh \
+    freetype fuse \
+    glibc-headers \
+    man nano openssh-server openssl098e libXext libXpm \
+	tcsh time \
+	zsh \
+    ; \
+    yum clean -y all
+
+RUN mkdir -p \
+    /cvmfs/cernvm-prod.cern.ch \
+    /cvmfs/sft.cern.ch \
+	/etc/cubie.d
+
+RUN echo "cernvm-prod.cern.ch /cvmfs/cernvm-prod.cern.ch cvmfs defaults 0 0" >> /etc/fstab && \
+    echo "sft.cern.ch         /cvmfs/sft.cern.ch cvmfs defaults 0 0" >> /etc/fstab
+
+WORKDIR /root
+
+## add files last (as this invalids caches)
+ADD https://github.com/hepsw/cubie/releases/download/${CUBIED_VERSION}/cubied /usr/bin/cubied
+ADD dot-pythonrc.py  $HOME/.pythonrc.py
+
+ADD etc-cvmfs-default-local /etc/cvmfs/default.local
+ADD etc-cvmfs-domain-local  /etc/cvmfs/domain.d/cern.ch.local
+ADD etc-cvmfs-keys          /etc/cvmfs/keys
+
+ADD etc-cubied-cvmfs.conf /etc/cubie.d/cvmfs.conf
+ADD run-cvmfs.sh /etc/cvmfs/run-cvmfs.sh
+
+RUN chmod uga+rx \
+	/etc/cvmfs/run-cvmfs.sh \
+	/usr/bin/cubied \
+	;
+
+## make the whole container seamlessly executable
+ENTRYPOINT ["/usr/bin/cubied"]
+CMD ["bash"]
+
+## EOF

--- a/cvmfs-base/Makefile
+++ b/cvmfs-base/Makefile
@@ -10,11 +10,16 @@ all: build
 
 build: Dockerfile
 	docker build --rm --tag=$(REPO):$(TAG) .
-	docker tag --force $(REPO):$(TAG) $(REPO):latest
+	docker tag $(REPO):$(TAG) $(REPO):latest
+
+build-cc7: Dockerfile-cc7
+	docker build --rm --tag=$(REPO)-cc7:$(TAG) --file Dockerfile-cc7 .
+	docker tag $(REPO)-cc7:$(TAG) $(REPO)-cc7:latest
 
 upload: build
 	docker push $(REPO):$(TAG)
 	docker push $(REPO):latest
 
-
-
+upload-cc7: build-cc7
+	docker push $(REPO)-cc7:$(TAG)
+	docker push $(REPO)-cc7:latest

--- a/cvmfs-cms/Dockerfile-cc7
+++ b/cvmfs-cms/Dockerfile-cc7
@@ -1,0 +1,28 @@
+##
+## hepsw/cvmfs-cms
+## A container where CernVM-FS is up and running
+##
+FROM hepsw/cvmfs-base-cc7
+LABEL maintainer="Patrick Gartung <gartung@fnal.gov>"
+
+USER root
+ENV USER root
+ENV HOME /root
+ENV VO_CMS_SW_DIR       /cvmfs/cms.cern.ch
+ENV CMS_LOCAL_ROOT_BASE /cvmfs/cms.cern.ch
+
+## make sure FUSE can be enabled
+RUN if [[ ! -e /dev/fuse ]]; then mknod -m 666 /dev/fuse c 10 229; fi
+
+WORKDIR /root
+
+RUN mkdir -p /cvmfs/cms.cern.ch && \
+    echo "cms.cern.ch /cvmfs/cms.cern.ch cvmfs defaults 0 0" >> /etc/fstab
+
+ADD dot-bashrc              $HOME/.bashrc
+
+## make the whole container seamlessly executable
+ENTRYPOINT ["/usr/bin/cubied"]
+CMD ["bash"]
+
+## EOF

--- a/cvmfs-cms/Makefile
+++ b/cvmfs-cms/Makefile
@@ -10,11 +10,16 @@ all: build
 
 build: Dockerfile
 	docker build --rm --tag=$(REPO):$(TAG) .
-	docker tag --force $(REPO):$(TAG) $(REPO):latest
+	docker tag $(REPO):$(TAG) $(REPO):latest
+
+build-cc7: Dockerfile-cc7
+	docker build --rm --tag=$(REPO)-cc7:$(TAG) --file Dockerfile-cc7 .
+	docker tag $(REPO)-cc7:$(TAG) $(REPO)-cc7:latest
 
 upload: build
 	docker push $(REPO):$(TAG)
 	docker push $(REPO):latest
 
-
-
+upload-cc7: build-cc7
+	docker push $(REPO)-cc7:$(TAG)
+	docker push $(REPO)-cc7:latest

--- a/cvmfs-lz/Dockerfile
+++ b/cvmfs-lz/Dockerfile
@@ -1,5 +1,5 @@
 ##
-## hepsw/cvmfs-cms
+## hepsw/cvmfs-lz
 ## A container where CernVM-FS is up and running
 ##
 FROM hepsw/cvmfs-base
@@ -8,8 +8,8 @@ MAINTAINER Luke Kreczko "kreczko@cern.ch"
 USER root
 ENV USER root
 ENV HOME /root
-ENV VO_LZ_SW_DIR       /cvmfs/cms.cern.ch
-ENV LZ_LOCAL_ROOT_BASE /cvmfs/cms.cern.ch
+ENV VO_LZ_SW_DIR       /cvmfs/lz.opensciencegrid.org
+ENV LZ_LOCAL_ROOT_BASE /cvmfs/lz.opensciencegrid.org
 
 ## make sure FUSE can be enabled
 RUN if [[ ! -e /dev/fuse ]]; then mknod -m 666 /dev/fuse c 10 229; fi

--- a/cvmfs-lz/Dockerfile-cc7
+++ b/cvmfs-lz/Dockerfile-cc7
@@ -1,0 +1,28 @@
+##
+## hepsw/cvmfs-cms
+## A container where CernVM-FS is up and running
+##
+FROM hepsw/cvmfs-base-cc7
+LABEL maintainer="Luke Kreczko <kreczko@cern.ch>"
+
+USER root
+ENV USER root
+ENV HOME /root
+ENV VO_LZ_SW_DIR       /cvmfs/cms.cern.ch
+ENV LZ_LOCAL_ROOT_BASE /cvmfs/cms.cern.ch
+
+## make sure FUSE can be enabled
+RUN if [[ ! -e /dev/fuse ]]; then mknod -m 666 /dev/fuse c 10 229; fi
+
+WORKDIR /root
+
+RUN mkdir -p /cvmfs/lz.opensciencegrid.org && \
+    echo "lz.opensciencegrid.org /cvmfs/lz.opensciencegrid.org cvmfs defaults 0 0" >> /etc/fstab
+
+ADD dot-bashrc              $HOME/.bashrc
+
+## make the whole container seamlessly executable
+ENTRYPOINT ["/usr/bin/cubied"]
+CMD ["bash"]
+
+## EOF

--- a/cvmfs-lz/Dockerfile-cc7
+++ b/cvmfs-lz/Dockerfile-cc7
@@ -1,5 +1,5 @@
 ##
-## hepsw/cvmfs-cms
+## hepsw/cvmfs-lz
 ## A container where CernVM-FS is up and running
 ##
 FROM hepsw/cvmfs-base-cc7
@@ -8,8 +8,8 @@ LABEL maintainer="Luke Kreczko <kreczko@cern.ch>"
 USER root
 ENV USER root
 ENV HOME /root
-ENV VO_LZ_SW_DIR       /cvmfs/cms.cern.ch
-ENV LZ_LOCAL_ROOT_BASE /cvmfs/cms.cern.ch
+ENV VO_LZ_SW_DIR       /cvmfs/lz.opensciencegrid.org
+ENV LZ_LOCAL_ROOT_BASE /cvmfs/lz.opensciencegrid.org
 
 ## make sure FUSE can be enabled
 RUN if [[ ! -e /dev/fuse ]]; then mknod -m 666 /dev/fuse c 10 229; fi

--- a/cvmfs-lz/Makefile
+++ b/cvmfs-lz/Makefile
@@ -12,6 +12,14 @@ build: Dockerfile
 	docker build --rm --tag=$(REPO):$(TAG) .
 	docker tag $(REPO):$(TAG) $(REPO):latest
 
+build-cc7: Dockerfile-cc7
+	docker build --rm --tag=$(REPO)-cc7:$(TAG) --file Dockerfile-cc7 .
+	docker tag $(REPO)-cc7:$(TAG) $(REPO)-cc7:latest
+
 upload: build
 	docker push $(REPO):$(TAG)
 	docker push $(REPO):latest
+
+upload-cc7: build-cc7
+	docker push $(REPO)-cc7:$(TAG)
+	docker push $(REPO)-cc7:latest


### PR DESCRIPTION
Adding Centos 7 versions for
 - hepsw/cvmfs-base
 - hepsw/cvmfs-cms
 - hepsw/cvmfs-lz

Also updated `cc7-base` as `centos:7` docker image now points to version 7.4 and removed the [deprecated & removed](https://docs.docker.com/engine/deprecated/#--automated-and---stars-flags-on-docker-search) `docker tag --force` flag from respective make files.

The following images need to be built and updated on [docker hub](https://hub.docker.com/u/hepsw/):
```bash
cd cc7-base
make && make upload
cd ../cvmfs-base
make build-cc7 && make upload-cc7
cd ../cvmfs-cms
make build-cc7 && make upload-cc7
cd ../cvmfs-lz
make build-cc7 && make upload-cc7
```

Partially fixes #22 