### PR TITLE
provide links to alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@ docks
 
 `docks` is a set of `Dockerfile` defining docker containers for `HEP`
 software and appliances.
+
+Maintenance note
+================
+
+As alternative to the `Dockerfile`s provided here, LHCb also maintains their
+own docker images at the [CERN gitlab container registry][lhcbcontainer]
+together with a [user script][lhcbscript]. These may have more up-to-date
+support for using LHCb applications.
+
+
+[lhcbcontainer]:   https://gitlab.cern.ch/lhcb-core/LbDocker/container_registry
+[lhcbscript]:      https://gitlab.cern.ch/lhcb-core/LbDocker/blob/master/scripts/lb-docker-run


### PR DESCRIPTION
I appreciate the Dockerfiles you have here, but given LHCb maintains docker
images for the nightly builds and hackathon setups, I was thinking it's worth
advertising to users that those by lhcb-dev exist, too.

A note in the README seems the least controversial to me, one can of cause also
think about adding a note into the Dockerfiles or the containers (such that
they print upon startup), or just mirroring the offical ones, or, or, or.
